### PR TITLE
feat(InstrumentConfiguration):add configuration for the instrument

### DIFF
--- a/src/DeribitSolution/Program.cs
+++ b/src/DeribitSolution/Program.cs
@@ -28,16 +28,8 @@ var host = Host.CreateDefaultBuilder()
     })
     .ConfigureServices(services => {
         services.AddSingleton<IConfiguration>(config);
-        services.AddOptions<DeribitOptions>()
-                .Bind(config.GetSection(nameof(DeribitOptions)))
-                .Validate(config =>
-                {
-                    if (string.IsNullOrEmpty(config.ApiKey) || string.IsNullOrEmpty(config.ApiSecret))
-                        return false;
-                    return true;
-                });
         services.AddLogging();
-        services.AddServiceClient();
+        services.AddServiceClient(config);
         services.AddTransient<Pipeline>();
         services.AddTransient<AsyncLogCommand>();
         services.AddTransient<AsyncSpectreCommand>();

--- a/src/DeribitSolution/appsettings.json
+++ b/src/DeribitSolution/appsettings.json
@@ -1,6 +1,13 @@
 {
   "DeribitOptions": {
-    "ApiSecret": "XIwzuFRkWhH0yyFaN6-KVPyde3khF6N7n82XfyTxbxo",
-    "ApiKey": "iRm_3a1E"
+    "ApiKey": "iRm_3a1E",
+    "ApiSecret": "XIwzuFRkWhH0yyFaN6-KVPyde3khF6N7n82XfyTxbxo"
+  },
+
+  "InstrumentConfiguration": {
+    "InstrumentName": "BTC-PERPETUAL",
+    "TickerInterval": "raw",
+    "BookInterval": "raw"
   }
+
 }

--- a/src/ServiceClient/DTOs/Instrument.cs
+++ b/src/ServiceClient/DTOs/Instrument.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace ServiceClient.DTOs
+{
+    public class InstrumentConfiguration
+    {
+        public string InstrumentName { get; set; } = string.Empty;
+        public string TickerInterval { get; set; } = string.Empty;
+        public string BookInterval { get; set; } = string.Empty;
+    }
+}

--- a/src/ServiceClient/ServiceClient.csproj
+++ b/src/ServiceClient/ServiceClient.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+	<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/ServiceClient/ServiceCollection.cs
+++ b/src/ServiceClient/ServiceCollection.cs
@@ -1,14 +1,32 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using ServiceClient.Abstractions;
+using ServiceClient.DTOs;
 using ServiceClient.Implements;
 
 namespace ServiceClient
 {
     public static class ServiceCollection
     {
-        public static void AddServiceClient(this IServiceCollection services)
+        public static void AddServiceClient(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddTransient<IServiceClient, MockServiceClient>();
+            services.AddOptions<DeribitOptions>()
+            .Bind(configuration.GetSection(nameof(DeribitOptions)))
+            .Validate(config =>
+            {
+                if (string.IsNullOrEmpty(config.ApiKey) || string.IsNullOrEmpty(config.ApiSecret))
+                    return false;
+                return true;
+            });
+            services.AddOptions<InstrumentConfiguration>()
+            .Bind(configuration.GetSection(nameof(InstrumentConfiguration)))
+            .Validate(config =>
+            {
+                if (string.IsNullOrEmpty(config.InstrumentName) || string.IsNullOrEmpty(config.TickerInterval) || string.IsNullOrEmpty(config.BookInterval))
+                    return false;
+                return true;
+            });
         }
     }
 }


### PR DESCRIPTION
An instrument DTO was created and loaded using IOption from appsetting. The DTO has the instrument name and the intervals for book and ticker. Added also validation for the 3 fields.

close#10